### PR TITLE
Remove warning from test

### DIFF
--- a/test/test_gyazo.rb
+++ b/test/test_gyazo.rb
@@ -9,12 +9,12 @@ class TestGyazo < MiniTest::Test
 
   def test_upload_filepath
     res = @gyazo.upload @imagefile
-    assert res['permalink_url'].match /^https?:\/\/gyazo.com\/[a-z\d]{32}$/i
+    assert res['permalink_url'].match(/^https?:\/\/gyazo.com\/[a-z\d]{32}$/i)
   end
 
   def test_upload_file
     res = @gyazo.upload File.open(@imagefile)
-    assert res['permalink_url'].match /^https?:\/\/gyazo.com\/[a-z\d]{32}$/i
+    assert res['permalink_url'].match(/^https?:\/\/gyazo.com\/[a-z\d]{32}$/i)
   end
 
   def test_list


### PR DESCRIPTION
This removes warnings below:

```
test/test_gyazo.rb:12: warning: ambiguous first argument; put parentheses or a space even after `/' operator
test/test_gyazo.rb:17: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```